### PR TITLE
Support invitation-based registration feature flags (#181)

### DIFF
--- a/src/client/api/ConfigurationApi.ts
+++ b/src/client/api/ConfigurationApi.ts
@@ -16,7 +16,8 @@ export class ConfigurationApi extends AbstractApi {
   > {
     return this.get({
       path: '/api/v1/flow/configuration',
-      schema: configurationResourceSchema
+      schema: configurationResourceSchema,
+      authenticated: true
     })
   }
 }

--- a/src/client/model/config/FeaturesConfigurationResource.ts
+++ b/src/client/model/config/FeaturesConfigurationResource.ts
@@ -1,9 +1,15 @@
 import type { JSONSchemaType } from 'ajv'
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface FeaturesConfigurationResource {}
+export interface FeaturesConfigurationResource {
+  sign_up_enabled?: boolean
+  invitation_enabled?: boolean
+}
 
 export const featuresConfigurationResourceSchema: JSONSchemaType<FeaturesConfigurationResource> = {
   type: 'object',
+  properties: {
+    sign_up_enabled: { type: 'boolean', nullable: true },
+    invitation_enabled: { type: 'boolean', nullable: true }
+  },
   additionalProperties: true
 }

--- a/src/components/signin/ByPasswordCard.vue
+++ b/src/components/signin/ByPasswordCard.vue
@@ -61,7 +61,7 @@ const loginLabel = computed(() => {
       {{ t('components.by_password_card.title') }}
     </template>
     <template v-slot:default>
-      <div class="mb-3 w-full text-center">
+      <div v-if="configuration.features.sign_up_enabled !== false" class="mb-3 w-full text-center">
         <i18n-t keypath="components.by_password_card.no_account">
           <router-link :to="{ name: 'SignUp' }" class="text-primary underline">
             {{ t('components.by_password_card.sign_up_action') }}


### PR DESCRIPTION
## Summary
- Authenticate the configuration API request with state, matching the backend change that now requires state auth on `GET /api/v1/flow/configuration`
- Add typed `sign_up_enabled` and `invitation_enabled` feature flags to the `FeaturesConfigurationResource` model
- Hide the "Sign Up!" link on the sign-in page when `sign_up_enabled` is `false`

Companion to sympauthy/sympauthy#232.

## Test plan
- [x] Verify `npm run build` passes (type-check + vite build)
- [x] With backend running: sign-in page shows "Sign Up!" link when `sign_up_enabled` is `true` or absent
- [x] With backend running: sign-in page hides "Sign Up!" link when `sign_up_enabled` is `false`
- [x] Configuration endpoint still loads correctly with state auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)