### PR TITLE
Align sign-up/sign-in flow with identifier_claims change (sympauthy#283)

### DIFF
--- a/src/client/model/PasswordResource.ts
+++ b/src/client/model/PasswordResource.ts
@@ -1,4 +1,6 @@
 import type { JSONSchemaType } from 'ajv'
+import type { CollectableClaimResource } from '@/client/model/CollectableClaimResource'
+import { collectableClaimResourceSchema } from '@/client/model/CollectableClaimResource'
 
 /**
  * Password authentication configuration for a flow step.
@@ -7,7 +9,11 @@ import type { JSONSchemaType } from 'ajv'
  * A `null` value means the password method is disabled for that step.
  */
 export interface PasswordResource {
-  identifier_claims: Array<string>
+  /**
+   * Claims that uniquely identify a user. Used as the login during sign-in and
+   * as the required claims collected during sign-up.
+   */
+  identifier_claims: Array<CollectableClaimResource>
 }
 
 export const passwordResourceSchema: JSONSchemaType<PasswordResource> = {
@@ -16,7 +22,7 @@ export const passwordResourceSchema: JSONSchemaType<PasswordResource> = {
     identifier_claims: {
       type: 'array',
       items: {
-        type: 'string'
+        ...collectableClaimResourceSchema
       }
     }
   },

--- a/src/client/model/SignUpFlowResource.ts
+++ b/src/client/model/SignUpFlowResource.ts
@@ -1,8 +1,6 @@
 import type { JSONSchemaType } from 'ajv'
 import type { PasswordResource } from '@/client/model/PasswordResource'
 import { passwordResourceSchema } from '@/client/model/PasswordResource'
-import type { CollectableClaimResource } from '@/client/model/CollectableClaimResource'
-import { collectableClaimResourceSchema } from '@/client/model/CollectableClaimResource'
 
 /**
  * Configuration of the sign-up step.
@@ -17,10 +15,11 @@ import { collectableClaimResourceSchema } from '@/client/model/CollectableClaimR
  * the flow `state` already appended.
  */
 export interface SignUpFlowResource {
-  /** Password sign-up configuration; null/absent when password sign-up is disabled. */
+  /**
+   * Password sign-up configuration; null/absent when password sign-up is disabled.
+   * The claims to collect at sign-up are exposed as `password.identifier_claims`.
+   */
   password?: PasswordResource
-  /** Claims to collect at sign-up. */
-  claims?: Array<CollectableClaimResource>
   /** Link to the sign-in step; present iff sign-in is allowed (absent during an invitation flow). */
   sign_in_redirect_url?: string
   /** Set when sign-up does not apply; the end-user should be redirected there. */
@@ -32,13 +31,6 @@ export const signUpFlowResourceSchema: JSONSchemaType<SignUpFlowResource> = {
   properties: {
     password: {
       ...passwordResourceSchema,
-      nullable: true
-    },
-    claims: {
-      type: 'array',
-      items: {
-        ...collectableClaimResourceSchema
-      },
       nullable: true
     },
     sign_in_redirect_url: {

--- a/src/components/signin/ByPasswordCard.vue
+++ b/src/components/signin/ByPasswordCard.vue
@@ -48,7 +48,12 @@ const onSubmit = handleSubmit(async (values: any) => {
   }
 })
 
-const loginLabel = computed(() => or(i18n, props.password.identifier_claims ?? []))
+const loginLabel = computed(() =>
+  or(
+    i18n,
+    (props.password.identifier_claims ?? []).map((claim) => claim.name)
+  )
+)
 
 async function onSignUpClick() {
   if (props.signUpRedirectUrl) {

--- a/src/pages/SignUpPage.vue
+++ b/src/pages/SignUpPage.vue
@@ -76,7 +76,7 @@ onMounted(async () => {
       await redirectOrPush(router, response.content.redirect_url)
       return
     }
-    signUpClaims.value = response.content.claims ?? []
+    signUpClaims.value = response.content.password?.identifier_claims ?? []
     passwordEnabled.value = response.content.password != null
     signInRedirectUrl.value = response.content.sign_in_redirect_url
     isLoading.value = false


### PR DESCRIPTION
## Context

Backend PR [sympauthy/sympauthy#283](https://github.com/sympauthy/sympauthy/pull/283) restructured how identifier claims are exposed in the flow API:

- `SignUpFlowResource.claims` (top-level) was **removed**.
- `PasswordResource.identifier_claims` changed from `List<String>` (`["email"]`) to `List<CollectableClaimResource>` (`[{id, required, name, type, group}]`). The JSON key stays `identifier_claims`, and the claims collected at sign-up are now exposed via `password.identifier_claims`.

Without this change the frontend breaks in three places.

## What broke

1. **🔴 Schema validation failed → both sign-in and sign-up pages broke.** `passwordResourceSchema` declared `identifier_claims` items as strings; the backend now sends objects. Since that schema is embedded in both `SignInFlowResource` and `SignUpFlowResource`, both config fetches failed AJV validation and returned `api.unknown`, routing users to the error page.
2. **🔴 Sign-up collected no claims.** `SignUpPage` read the removed top-level `claims`, so the form rendered no input fields.
3. **🟠 Sign-in login label rendered `[object Object]`.** `or()` expects `Array<string>` but received claim objects.

## Changes

- **`PasswordResource.ts`** — retype `identifier_claims` to `Array<CollectableClaimResource>` and validate with `collectableClaimResourceSchema`. (Root-cause fix for #1.)
- **`SignUpPage.vue`** — source claims from `password.identifier_claims`.
- **`SignUpFlowResource.ts`** — drop the now-dead top-level `claims` field.
- **`ByPasswordCard.vue`** — map `identifier_claims` to `claim.name` before building the login label.

## Notes

- The sign-in login label now uses `claim.name` (localized display name from the new resource) rather than the raw claim id it joined before. Happy to switch to `claim.id` if preserving the exact old text is preferred.
- `type-check`, `lint`, and `format` all pass. No test framework is configured in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)