### PR TITLE
Add CONFIRM step to the interactive flow

### DIFF
--- a/src/client/api/CancelApi.ts
+++ b/src/client/api/CancelApi.ts
@@ -1,0 +1,24 @@
+import { AbstractApi } from '@/client/AbstractApi'
+import type { Pinia } from 'pinia'
+import type { InjectionKey } from 'vue'
+import type { FlowResource } from '@/client/model/FlowResource'
+import { flowResultResourceSchema } from '@/client/model/FlowResource'
+import type { ErrorApiResponse } from '@/client/ErrorApiResponse'
+import type { SuccessApiResponse } from '@/client/SuccessApiResponse'
+
+export class CancelApi extends AbstractApi {
+  constructor(pinia: Pinia) {
+    super(pinia)
+  }
+
+  async cancel(): Promise<SuccessApiResponse<FlowResource> | ErrorApiResponse> {
+    return this.post({
+      authenticated: true,
+      path: '/api/v1/flow/cancel',
+      body: {},
+      schema: flowResultResourceSchema
+    })
+  }
+}
+
+export const cancelApiKey: InjectionKey<CancelApi> = Symbol('CancelApi')

--- a/src/client/api/ConfirmApi.ts
+++ b/src/client/api/ConfirmApi.ts
@@ -1,0 +1,34 @@
+import { AbstractApi } from '@/client/AbstractApi'
+import type { Pinia } from 'pinia'
+import type { InjectionKey } from 'vue'
+import type { ConfirmFlowResource } from '@/client/model/ConfirmFlowResource'
+import { confirmFlowResourceSchema } from '@/client/model/ConfirmFlowResource'
+import type { FlowResource } from '@/client/model/FlowResource'
+import { flowResultResourceSchema } from '@/client/model/FlowResource'
+import type { ErrorApiResponse } from '@/client/ErrorApiResponse'
+import type { SuccessApiResponse } from '@/client/SuccessApiResponse'
+
+export class ConfirmApi extends AbstractApi {
+  constructor(pinia: Pinia) {
+    super(pinia)
+  }
+
+  async fetchConfirmation(): Promise<SuccessApiResponse<ConfirmFlowResource> | ErrorApiResponse> {
+    return this.get({
+      authenticated: true,
+      path: '/api/v1/flow/confirm',
+      schema: confirmFlowResourceSchema
+    })
+  }
+
+  async confirm(): Promise<SuccessApiResponse<FlowResource> | ErrorApiResponse> {
+    return this.post({
+      authenticated: true,
+      path: '/api/v1/flow/confirm',
+      body: {},
+      schema: flowResultResourceSchema
+    })
+  }
+}
+
+export const confirmApiKey: InjectionKey<ConfirmApi> = Symbol('ConfirmApi')

--- a/src/client/model/ConfirmFlowResource.ts
+++ b/src/client/model/ConfirmFlowResource.ts
@@ -1,0 +1,27 @@
+import type { JSONSchemaType } from 'ajv'
+
+export type ConfirmFlowResource = {
+  action?: string
+  initiating_client_id?: string
+  redirect_url?: string
+}
+
+export const confirmFlowResourceSchema: JSONSchemaType<ConfirmFlowResource> = {
+  type: 'object',
+  properties: {
+    action: {
+      type: 'string',
+      nullable: true
+    },
+    initiating_client_id: {
+      type: 'string',
+      nullable: true
+    },
+    redirect_url: {
+      type: 'string',
+      nullable: true
+    }
+  },
+  anyOf: [{ required: ['redirect_url'] }, { required: ['action'] }],
+  additionalProperties: true
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -87,6 +87,18 @@
       "submit": "Confirm",
       "submitting": "Confirming..."
     },
+    "confirm": {
+      "title": "Did you request this?",
+      "description": "{client} asked to {action} on your account. Only continue if you started this action.",
+      "description_no_client": "You have been asked to {action} on your account. Only continue if you started this action.",
+      "actions": {
+        "ENROLL_MFA": "set up two-factor authentication"
+      },
+      "confirm": "Yes, continue",
+      "confirming": "Confirming...",
+      "cancel": "No, cancel",
+      "cancelling": "Cancelling..."
+    },
     "error": {
       "title": "Something went wrong"
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,8 @@ import { ClaimsValidationApi, claimsValidationApiKey } from '@/client/api/Claims
 import { ErrorApi, errorApiKey } from '@/client/api/ErrorApi'
 import { MfaApi, mfaApiKey } from '@/client/api/MfaApi'
 import { TotpApi, totpApiKey } from '@/client/api/TotpApi'
+import { ConfirmApi, confirmApiKey } from '@/client/api/ConfirmApi'
+import { CancelApi, cancelApiKey } from '@/client/api/CancelApi'
 
 const pinia = createPinia()
 const router = makeRouter()
@@ -26,6 +28,8 @@ createApp(App)
   .provide(errorApiKey, new ErrorApi(pinia))
   .provide(mfaApiKey, new MfaApi(pinia))
   .provide(totpApiKey, new TotpApi(pinia))
+  .provide(confirmApiKey, new ConfirmApi(pinia))
+  .provide(cancelApiKey, new CancelApi(pinia))
   .use(router)
   .use(i18n)
   .use(pinia)

--- a/src/pages/ConfirmPage.vue
+++ b/src/pages/ConfirmPage.vue
@@ -1,0 +1,141 @@
+<script lang="ts" setup>
+import BasePage from '@/components/BasePage.vue'
+import TitleContentCard from '@/components/card/TitleContentCard.vue'
+import CommonAlert from '@/components/CommonAlert.vue'
+import CommonButton from '@/components/CommonButton.vue'
+import { injectRequired, redirectOrPush } from '@/utils/VueUtils'
+import { confirmApiKey } from '@/client/api/ConfirmApi'
+import { cancelApiKey } from '@/client/api/CancelApi'
+import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import { SuccessApiResponse } from '@/client/SuccessApiResponse'
+import { getErrorMessage } from '@/client/ErrorApiResponse'
+import { secondaryButton } from '@/styles/ButtonStyle'
+
+const { t } = useI18n()
+const router = useRouter()
+const confirmApi = injectRequired(confirmApiKey)
+const cancelApi = injectRequired(cancelApiKey)
+
+const fetchErrorMessage = ref<string | undefined>(undefined)
+const action = ref<string | undefined>(undefined)
+const initiatingClientId = ref<string | undefined>(undefined)
+
+const submitErrorMessage = ref<string | undefined>(undefined)
+const isConfirming = ref(false)
+const isCancelling = ref(false)
+
+// The action code is machine-readable (e.g. ENROLL_MFA); resolve a human label, falling back to the raw code.
+const description = computed(() => {
+  if (action.value === undefined) {
+    return ''
+  }
+  const actionLabel = t(`pages.confirm.actions.${action.value}`, action.value)
+  return initiatingClientId.value !== undefined
+    ? t('pages.confirm.description', { client: initiatingClientId.value, action: actionLabel })
+    : t('pages.confirm.description_no_client', { action: actionLabel })
+})
+
+onMounted(async () => {
+  const response = await confirmApi.fetchConfirmation()
+  if (response instanceof SuccessApiResponse) {
+    if (response.content.redirect_url !== undefined) {
+      // The end-user is not expected on the confirmation step (already confirmed or no confirmation).
+      await redirectOrPush(router, response.content.redirect_url)
+    } else {
+      action.value = response.content.action
+      initiatingClientId.value = response.content.initiating_client_id
+    }
+  } else {
+    fetchErrorMessage.value = getErrorMessage(response)
+  }
+})
+
+const onConfirm = async () => {
+  submitErrorMessage.value = undefined
+  isConfirming.value = true
+
+  const response = await confirmApi.confirm()
+  if (response instanceof SuccessApiResponse) {
+    await redirectOrPush(router, response.content.redirect_url)
+  } else {
+    submitErrorMessage.value = getErrorMessage(response)
+    isConfirming.value = false
+  }
+}
+
+const onCancel = async () => {
+  submitErrorMessage.value = undefined
+  isCancelling.value = true
+
+  const response = await cancelApi.cancel()
+  if (response instanceof SuccessApiResponse) {
+    await redirectOrPush(router, response.content.redirect_url)
+  } else {
+    submitErrorMessage.value = getErrorMessage(response)
+    isCancelling.value = false
+  }
+}
+</script>
+
+<template>
+  <base-page>
+    <div class="flex justify-center w-full">
+      <title-content-card v-if="action" size="default">
+        <template v-slot:title>
+          {{ t('pages.confirm.title') }}
+        </template>
+
+        <template v-slot:default>
+          <common-alert v-if="submitErrorMessage" class="mb-3">
+            {{ submitErrorMessage }}
+          </common-alert>
+
+          <p class="w-full mb-7 text-justify">
+            {{ description }}
+          </p>
+
+          <div class="flex flex-col gap-3 w-full">
+            <common-button
+              :submitting="isConfirming"
+              :disabled="isCancelling"
+              class="w-full"
+              type="button"
+              @click="onConfirm"
+            >
+              <template v-slot:default>
+                {{ t('pages.confirm.confirm') }}
+              </template>
+              <template v-slot:submitting>
+                {{ t('pages.confirm.confirming') }}
+              </template>
+            </common-button>
+
+            <common-button
+              :button-style="secondaryButton"
+              :submitting="isCancelling"
+              :disabled="isConfirming"
+              class="w-full"
+              type="button"
+              @click="onCancel"
+            >
+              <template v-slot:default>
+                {{ t('pages.confirm.cancel') }}
+              </template>
+              <template v-slot:submitting>
+                {{ t('pages.confirm.cancelling') }}
+              </template>
+            </common-button>
+          </div>
+        </template>
+      </title-content-card>
+
+      <title-content-card v-else :loading="!fetchErrorMessage" :error="fetchErrorMessage">
+        <template v-slot:title>{{ t('pages.confirm.title') }}</template>
+      </title-content-card>
+    </div>
+  </base-page>
+</template>
+
+<style scoped></style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -15,6 +15,7 @@ import ValidateClaimsPage from '@/pages/claims/ValidateClaimsPage.vue'
 import MfaSelectionPage from '@/pages/mfa/MfaSelectionPage.vue'
 import TotpChallengePage from '@/pages/mfa/TotpChallengePage.vue'
 import TotpEnrollPage from '@/pages/mfa/TotpEnrollPage.vue'
+import ConfirmPage from '@/pages/ConfirmPage.vue'
 import { isArrayNotEmpty } from '@/utils/ArrayUtils.ts'
 import { isString } from '@/utils/StringUtils.ts'
 
@@ -87,6 +88,14 @@ export function makeRouter(): Router {
         path: '/',
         name: 'Home',
         redirect: '/sign-in'
+      },
+      {
+        path: '/confirm',
+        name: 'Confirm',
+        component: ConfirmPage,
+        meta: {
+          stateRequired: true
+        }
       },
       {
         path: '/sign-in',

--- a/src/styles/ButtonStyle.ts
+++ b/src/styles/ButtonStyle.ts
@@ -23,3 +23,10 @@ export const primaryColoredButton: ButtonStyle = Object.freeze({
   submittingClasses: 'bg-(--color-primary) text-(--color-on-primary) cursor-wait',
   disabledClasses: 'bg-(--color-disabled) text-(--color-on-disabled) pointer-events-none'
 })
+
+export const secondaryButton: ButtonStyle = Object.freeze({
+  activeClasses: 'bg-transparent text-(--color-primary) border-(--color-primary)',
+  loadingClasses: 'bg-transparent text-(--color-primary) border-(--color-primary) cursor-wait',
+  submittingClasses: 'bg-transparent text-(--color-primary) border-(--color-primary) cursor-wait',
+  disabledClasses: 'bg-(--color-disabled) text-(--color-on-disabled) pointer-events-none'
+})


### PR DESCRIPTION
## Context

Backend PR [sympauthy/sympauthy#291](https://github.com/sympauthy/sympauthy/pull/291) introduces a generic **`CONFIRM`** interactive-flow step: a checkpoint where a signed-in end-user must explicitly approve an action a client (or an administrator) initiated on their behalf before the flow proceeds. Its first consumer is standalone MFA enrollment, whose session now starts as `[CONFIRM, MFA_ENROLLMENT]`. If the user approves, the flow continues; if they deny, the flow is cancelled and the user is handed back to the initiator.

This PR adds the custom UI the backend redirects the browser to (`/confirm`).

## API contract consumed

- `GET /api/v1/flow/confirm` → `{ action, initiating_client_id, redirect_url }`. When `redirect_url` is set, the other fields are null and the browser is redirected there (already confirmed / no confirm step).
- `POST /api/v1/flow/confirm` → `{ redirect_url }` — approve, then continue the flow.
- `POST /api/v1/flow/cancel` (existing generic endpoint) → `{ redirect_url }` — deny/cancel, then hand back to the initiator.

## Changes

**New**
- `src/client/model/ConfirmFlowResource.ts` — type + AJV schema (`anyOf` redirect-vs-content split, mirroring `MfaFlowResource`).
- `src/client/api/ConfirmApi.ts` — `fetchConfirmation()` (GET) and `confirm()` (POST).
- `src/client/api/CancelApi.ts` — dedicated `cancel()` for the generic `/flow/cancel` endpoint.
- `src/pages/ConfirmPage.vue` — fetches on mount, redirects out when the step does not apply, renders the action + initiating client, and offers **Confirm** (primary) / **Cancel** (secondary) with submitting/error states.

**Edited**
- `src/styles/ButtonStyle.ts` — reusable outlined `secondaryButton`.
- `src/router/index.ts` — `/confirm` route (`meta.stateRequired: true`).
- `src/main.ts` — provides `ConfirmApi` and `CancelApi`.
- `src/locales/en.json` — `pages.confirm` block.

## Notes

- The page displays the **client id** (`initiating_client_id`), the only client identifier the API returns — there is no client display-name source in the frontend. A friendlier name would require the backend to include one in `ConfirmFlowResource`.
- Admin-initiated actions (no `initiating_client_id`) use a separate `description_no_client` message.

## Verification

- ✅ `npm run type-check`, `npm run lint`, `npm run format`, and `npm run build` all pass.
- ⚠️ Not exercised end-to-end: requires the PR #291 backend running on `:8080`. Definitive test once available: start a standalone MFA enrollment (now begins with `CONFIRM`) and verify the page renders, **Confirm** advances to MFA enrollment, and **Cancel** hands back to the initiator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)