### PR TITLE
Warn user of re-authentication on the confirm page (#294)

### DIFF
--- a/src/client/model/ConfirmFlowResource.ts
+++ b/src/client/model/ConfirmFlowResource.ts
@@ -2,6 +2,7 @@ import type { JSONSchemaType } from 'ajv'
 
 export type ConfirmFlowResource = {
   action?: string
+  requires_reauthentication?: boolean
   initiating_client_id?: string
   redirect_url?: string
 }
@@ -11,6 +12,10 @@ export const confirmFlowResourceSchema: JSONSchemaType<ConfirmFlowResource> = {
   properties: {
     action: {
       type: 'string',
+      nullable: true
+    },
+    requires_reauthentication: {
+      type: 'boolean',
       nullable: true
     },
     initiating_client_id: {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -91,9 +91,11 @@
       "title": "Verify this request",
       "request": "{client} has requested to {action} on your account.",
       "request_no_client": "A request has been made to {action} on your account.",
+      "reauthentication_notice": "Because this is a security-sensitive operation, you will be asked to sign in again to confirm your identity before it is completed.",
       "warning": "To protect your account, do not continue unless you initiated this request.",
       "actions": {
-        "ENROLL_MFA": "set up two-factor authentication"
+        "ENROLL_MFA": "set up two-factor authentication",
+        "LINK_PROVIDER": "link an identity provider"
       },
       "confirm": "Yes, continue",
       "confirming": "Confirming...",

--- a/src/pages/ConfirmPage.vue
+++ b/src/pages/ConfirmPage.vue
@@ -20,6 +20,7 @@ const cancelApi = injectRequired(cancelApiKey)
 
 const fetchErrorMessage = ref<string | undefined>(undefined)
 const action = ref<string | undefined>(undefined)
+const requiresReauthentication = ref(false)
 const initiatingClientId = ref<string | undefined>(undefined)
 
 const submitErrorMessage = ref<string | undefined>(undefined)
@@ -45,6 +46,7 @@ onMounted(async () => {
       await redirectOrPush(router, response.content.redirect_url)
     } else {
       action.value = response.content.action
+      requiresReauthentication.value = response.content.requires_reauthentication ?? false
       initiatingClientId.value = response.content.initiating_client_id
     }
   } else {
@@ -94,6 +96,10 @@ const onCancel = async () => {
 
           <p class="w-full mb-3 text-justify">
             {{ request }}
+          </p>
+
+          <p v-if="requiresReauthentication" class="w-full mb-3 text-justify">
+            {{ t('pages.confirm.reauthentication_notice') }}
           </p>
 
           <p class="w-full mb-7 text-justify font-semibold">


### PR DESCRIPTION
Frontend counterpart to backend PR [sympauthy/sympauthy#304](https://github.com/sympauthy/sympauthy/pull/304), which adds the client/admin **provider-link** flow.

That PR extends the confirm flow in two ways the custom UI must handle:
- a new **`LINK_PROVIDER`** confirm action, and
- a server-computed **`requires_reauthentication`** boolean on the confirm flow resource.

Linking a provider mints a durable login credential, so the end-user is asked to re-authenticate before the link commits. This surfaces that up front on the confirm page so the user knows a second sign-in is coming.

## Changes

- **`ConfirmFlowResource.ts`** — add `requires_reauthentication?: boolean` to the type and the AJV schema.
- **`ConfirmPage.vue`** — read the flag (`?? false`) and render a notice paragraph between the request line and the warning, shown only when `true`.
- **`en.json`** — add two `pages.confirm` strings:
  - `reauthentication_notice` — the re-authentication heads-up.
  - `actions.LINK_PROVIDER` — the action label ("link an identity provider").

## Notes

- The notice is a plain paragraph matching the existing `warning` line. `CommonAlert` only has a red `danger` variant, which would read as an error rather than an informational heads-up.
- The backend defaults `requires_reauthentication` to `false` and treats it as irrelevant when a `redirect_url` is present; the page already redirects in that case before reading the field.

## Verification

- `npm run type-check` — clean
- `npm run format` — all files unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)